### PR TITLE
i2c::I2c methods are unreliable in 'release' builds

### DIFF
--- a/tm4c123x-hal/src/i2c.rs
+++ b/tm4c123x-hal/src/i2c.rs
@@ -1,6 +1,7 @@
 //! Inter-Integrated Circuit (I2C) bus
 
 use tm4c123x::{I2C0, I2C1, I2C2, I2C3};
+use cortex_m::asm::delay;
 
 use crate::gpio::gpioa::{PA6, PA7};
 use crate::gpio::gpiob::{PB2, PB3};
@@ -59,6 +60,12 @@ pub struct I2c<I2C, PINS> {
 
 macro_rules! busy_wait {
     ($i2c:expr, $flag:ident, $op:ident) => {
+        // in 'release' builds, the time between setting the `run` bit and checking the `busy`
+        // bit is too short and the `busy` bit is not reliably set by the time you get there,
+        // it can take up to 8 clock cycles for the `run` to begin so this delay allows time
+        // for that hardware synchronization
+        delay(2);
+
         loop {
             let mcs = $i2c.mcs.read();
 

--- a/tm4c129x-hal/src/i2c.rs
+++ b/tm4c129x-hal/src/i2c.rs
@@ -6,6 +6,7 @@ use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 use crate::sysctl::{self, Clocks};
 use crate::time::Hertz;
 use tm4c129x::{I2C0, I2C1, I2C2, I2C3};
+use cortex_m::asm::delay;
 
 /// I2C error
 #[derive(Debug)]
@@ -66,6 +67,12 @@ pub struct I2c<I2C, PINS> {
 
 macro_rules! busy_wait {
     ($i2c:expr, $flag:ident, $op:ident) => {
+        // in 'release' builds, the time between setting the `run` bit and checking the `busy`
+        // bit is too short and the `busy` bit is not reliably set by the time you get there,
+        // it can take up to 8 clock cycles for the `run` to begin so this delay allows time
+        // for that hardware synchronization
+        delay(2);
+
         loop {
             let mcs = $i2c.mcs.read();
 


### PR DESCRIPTION
When performing I2C transactions in 'release' builds, the time between
setting the `run` bit and checking the `busy` bit is too short and the
`busy` bit is not reliably set by the time you get there.

It can take up to 8 clock cycles for the `run` to begin so this commit
adds an 8 cycle delay in the i2c::busy_wait! macros before checking any
I2C hardware registers.

Signed-off-by: Michael Leonard <maybeillrememberit@gmail.com>