### PR TITLE
Package version updates:

### DIFF
--- a/examples/tiva-c-connected-launchpad/Cargo.toml
+++ b/examples/tiva-c-connected-launchpad/Cargo.toml
@@ -8,8 +8,8 @@ name = "tiva-c-connected-launchpad"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.5.8"
-cortex-m-rt = "0.6.5"
+cortex-m = "0.6"
+cortex-m-rt = "0.6"
 cortex-m-semihosting = "0.3.2"
 panic-halt = "0.2.0"
 

--- a/examples/tiva-c-launchpad/Cargo.toml
+++ b/examples/tiva-c-launchpad/Cargo.toml
@@ -8,8 +8,8 @@ name = "tiva-c-launchpad"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.5.8"
-cortex-m-rt = "0.6.5"
+cortex-m = "0.6"
+cortex-m-rt = "0.6"
 cortex-m-semihosting = "0.3.2"
 panic-halt = "0.2.0"
 

--- a/tm4c-hal/Cargo.toml
+++ b/tm4c-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c-hal"
-version = "0.2.3"
+version = "0.3.0"
 authors = [
 	"Jorge Aparicio <jorge@japaric.io>",
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.5"
+cortex-m = "0.6"
 
 [dependencies.embedded-hal]
 version = "0.2.2"

--- a/tm4c123x-hal/Cargo.toml
+++ b/tm4c123x-hal/Cargo.toml
@@ -37,7 +37,7 @@ default-features = false
 
 [dependencies.tm4c-hal]
 path = "../tm4c-hal"
-version = "0.2.3"
+version = "0.3.0"
 
 [features]
 rt = ["tm4c123x/rt"]

--- a/tm4c123x-hal/Cargo.toml
+++ b/tm4c123x-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c123x-hal"
-version = "0.9.2"
+version = "0.10.0"
 authors = [
 	"Jorge Aparicio <jorge@japaric.io>",
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
@@ -19,7 +19,7 @@ version = "0.2.2"
 default-features = false
 
 [dependencies.cortex-m]
-version = "0.5.2"
+version = "0.6"
 
 [dependencies.embedded-hal]
 version = "0.2.2"
@@ -29,8 +29,7 @@ features = ["unproven"]
 version = "0.1"
 
 [dependencies.tm4c123x]
-version = "0.7"
-# path = "../dslite2svd/crates/tm4c123x"
+version = "0.9"
 
 [dependencies.void]
 version = "1.0"

--- a/tm4c129x-hal/Cargo.toml
+++ b/tm4c129x-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tm4c129x-hal"
-version = "0.8.2"
+version = "0.9.0"
 authors = [
 	"Jorge Aparicio <jorge@japaric.io>",
 	"Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
@@ -15,9 +15,9 @@ repository = "https://github.com/thejpster/tm4c-hal/tm4c129x-hal"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.5"
+cortex-m = "0.6"
 nb = "0.1"
-tm4c129x = "0.7"
+tm4c129x = "0.9"
 
 [dependencies.cast]
 version = "0.2"

--- a/tm4c129x-hal/Cargo.toml
+++ b/tm4c129x-hal/Cargo.toml
@@ -32,8 +32,8 @@ version = "1.0"
 default-features = false
 
 [dependencies.tm4c-hal]
+version = "0.3.0"
 path = "../tm4c-hal"
-version = "0.2.3"
 
 [features]
 rt = ["tm4c129x/rt"]


### PR DESCRIPTION
* Use cortex-m 0.6 throughout
* Use latest tm4c12X PACs v0.9.0, built with svd2rust 0.16.1
* Bump own version numbers