### PR TITLE
Clean up imports and crate attributes

### DIFF
--- a/examples/tiva-c-connected-launchpad/src/main.rs
+++ b/examples/tiva-c-connected-launchpad/src/main.rs
@@ -1,12 +1,11 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt; // you can put a breakpoint on `rust_begin_unwind` to catch panics
-extern crate tm4c129x_hal as hal;
+use panic_halt as _; // you can put a breakpoint on `rust_begin_unwind` to catch panics
 
 use core::fmt::Write;
 use cortex_m_rt::entry;
-use hal::prelude::*;
+use tm4c129x_hal::{self as hal, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/examples/tiva-c-launchpad/src/main.rs
+++ b/examples/tiva-c-launchpad/src/main.rs
@@ -1,12 +1,11 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt; // you can put a breakpoint on `rust_begin_unwind` to catch panics
-extern crate tm4c123x_hal as hal;
+use panic_halt as _; // you can put a breakpoint on `rust_begin_unwind` to catch panics
 
 use core::fmt::Write;
 use cortex_m_rt::entry;
-use hal::prelude::*;
+use tm4c123x_hal::{self as hal, prelude::*};
 
 #[entry]
 fn main() -> ! {

--- a/tm4c-hal/src/delay.rs
+++ b/tm4c-hal/src/delay.rs
@@ -1,10 +1,7 @@
 //! Code for busy-waiting
 
-use crate::sysctl::Clocks;
-use crate::time::Hertz;
-use cast::u32;
-use cortex_m::peripheral::syst::SystClkSource;
-use cortex_m::peripheral::SYST;
+use crate::{sysctl::Clocks, time::Hertz};
+use cortex_m::peripheral::{syst::SystClkSource, SYST};
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 
 /// System timer (SysTick) as a delay provider
@@ -38,13 +35,13 @@ impl DelayMs<u32> for Delay {
 
 impl DelayMs<u16> for Delay {
     fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(u32(ms));
+        self.delay_ms(cast::u32(ms));
     }
 }
 
 impl DelayMs<u8> for Delay {
     fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(u32(ms));
+        self.delay_ms(cast::u32(ms));
     }
 }
 
@@ -75,12 +72,12 @@ impl DelayUs<u32> for Delay {
 
 impl DelayUs<u16> for Delay {
     fn delay_us(&mut self, us: u16) {
-        self.delay_us(u32(us))
+        self.delay_us(cast::u32(us))
     }
 }
 
 impl DelayUs<u8> for Delay {
     fn delay_us(&mut self, us: u8) {
-        self.delay_us(u32(us))
+        self.delay_us(cast::u32(us))
     }
 }

--- a/tm4c-hal/src/lib.rs
+++ b/tm4c-hal/src/lib.rs
@@ -1,12 +1,8 @@
 //! Generic implementation code for both TM4C123 and TM4C129.
 
 #![no_std]
-#![deny(missing_docs)]
-#![deny(warnings)]
+#![deny(missing_docs, warnings)]
 #![allow(deprecated)]
-
-extern crate embedded_hal as hal;
-extern crate nb;
 
 pub mod bb;
 pub mod delay;

--- a/tm4c123x-hal/src/gpio.rs
+++ b/tm4c123x-hal/src/gpio.rs
@@ -34,9 +34,11 @@
 
 pub use tm4c_hal::gpio::*;
 
-use crate::bb;
-use crate::hal::digital::{InputPin, OutputPin, StatefulOutputPin};
-use crate::sysctl;
+use crate::{
+    bb,
+    hal::digital::{InputPin, OutputPin, StatefulOutputPin},
+    sysctl,
+};
 use core::marker::PhantomData;
 use tm4c_hal::gpio_macro;
 

--- a/tm4c123x-hal/src/i2c.rs
+++ b/tm4c123x-hal/src/i2c.rs
@@ -3,17 +3,18 @@
 use cortex_m::asm::delay;
 use tm4c123x::{I2C0, I2C1, I2C2, I2C3};
 
-use crate::gpio::gpioa::{PA6, PA7};
-use crate::gpio::gpiob::{PB2, PB3};
-use crate::gpio::gpiod::{PD0, PD1};
-use crate::gpio::gpioe::{PE4, PE5};
-
-use crate::gpio::{AlternateFunction, Floating, OpenDrain, OutputMode, AF3};
-
-use crate::sysctl::{self, Clocks};
-
-use crate::hal::blocking::i2c::{Read, Write, WriteRead};
-use crate::time::Hertz;
+use crate::{
+    gpio::{
+        gpioa::{PA6, PA7},
+        gpiob::{PB2, PB3},
+        gpiod::{PD0, PD1},
+        gpioe::{PE4, PE5},
+        AlternateFunction, Floating, OpenDrain, OutputMode, AF3,
+    },
+    hal::blocking::i2c::{Read, Write, WriteRead},
+    sysctl::{self, Clocks},
+    time::Hertz,
+};
 
 /// I2C error
 #[derive(Debug)]

--- a/tm4c123x-hal/src/lib.rs
+++ b/tm4c123x-hal/src/lib.rs
@@ -19,14 +19,14 @@
 //!
 //! [`f3`]: https://docs.rs/f3/~0.5.1
 
-#![deny(missing_docs)]
-#![deny(warnings)]
+#![deny(missing_docs, warnings)]
 #![allow(deprecated)]
 #![no_std]
 
-pub use tm4c_hal::bb;
-pub use tm4c_hal::delay;
-pub use tm4c_hal::time;
+pub use tm4c123x::{self, CorePeripherals, Peripherals};
+pub use tm4c_hal::{bb, delay, time};
+
+use embedded_hal as hal;
 
 pub mod gpio;
 pub mod i2c;
@@ -35,8 +35,3 @@ pub mod serial;
 pub mod spi;
 pub mod sysctl;
 pub mod timer;
-
-extern crate embedded_hal as hal;
-extern crate nb;
-pub use tm4c123x;
-pub use tm4c123x::{CorePeripherals, Peripherals};

--- a/tm4c123x-hal/src/prelude.rs
+++ b/tm4c123x-hal/src/prelude.rs
@@ -1,6 +1,9 @@
 //! Prelude
 
-pub use crate::gpio::GpioExt as _tm4c123x_hal_gpio_GpioExt;
-pub use crate::hal::prelude::*;
-pub use crate::sysctl::SysctlExt;
-pub use crate::time::U32Ext;
+#[rustfmt::skip]
+pub use crate::{
+    gpio::GpioExt as _,
+    hal::prelude::*,
+    sysctl::SysctlExt,
+    time::U32Ext,
+};

--- a/tm4c123x-hal/src/serial.rs
+++ b/tm4c123x-hal/src/serial.rs
@@ -1,25 +1,22 @@
 //! Serial
 
-use core::fmt;
-use core::marker::PhantomData;
-
-use crate::hal::prelude::*;
-use crate::hal::serial;
-use nb::{self, block};
 pub use tm4c123x::{UART0, UART1, UART2, UART3, UART4, UART5, UART6, UART7};
+pub use tm4c_hal::{serial::*, uart_hal_macro, uart_pin_macro};
+
+#[rustfmt::skip]
+use crate::{
+    gpio::{
+        gpioa, gpiob, gpioc, gpiod, gpioe, gpiof,
+        AlternateFunction, OutputMode, AF1, AF2, AF8,
+    },
+    hal::{prelude::*, serial},
+    sysctl,
+    sysctl::Clocks,
+    time::Bps,
+};
+use core::{fmt, marker::PhantomData};
+use nb::{self, block};
 use void::Void;
-
-use crate::gpio::{gpioa, gpiob, gpioc, gpiod, gpioe, gpiof};
-use crate::gpio::{AlternateFunction, OutputMode, AF1, AF2, AF8};
-use crate::sysctl;
-use crate::sysctl::Clocks;
-use crate::time::Bps;
-
-pub use tm4c_hal::serial::*;
-
-pub use tm4c_hal::serial::*;
-
-pub use tm4c_hal::{uart_hal_macro, uart_pin_macro};
 
 /// Serial abstraction
 pub struct Serial<UART, TX, RX, RTS, CTS> {

--- a/tm4c123x-hal/src/spi.rs
+++ b/tm4c123x-hal/src/spi.rs
@@ -2,14 +2,18 @@
 
 pub use crate::hal::spi::{Mode, MODE_0, MODE_1, MODE_2, MODE_3};
 
-use crate::gpio::gpioa::{PA2, PA4, PA5};
-use crate::gpio::gpiob::{PB4, PB6, PB7};
-use crate::gpio::gpiod::{PD0, PD2, PD3};
-use crate::gpio::{AlternateFunction, OutputMode, AF1, AF2};
-use crate::hal::spi::{FullDuplex, Phase, Polarity};
-use crate::sysctl;
-use crate::sysctl::Clocks;
-use crate::time::Hertz;
+use crate::{
+    gpio::{
+        gpioa::{PA2, PA4, PA5},
+        gpiob::{PB4, PB6, PB7},
+        gpiod::{PD0, PD2, PD3},
+        AlternateFunction, OutputMode, AF1, AF2,
+    },
+    hal::spi::{FullDuplex, Phase, Polarity},
+    sysctl,
+    sysctl::Clocks,
+    time::Hertz,
+};
 
 use nb;
 use tm4c123x::{SSI0, SSI1, SSI2, SSI3};

--- a/tm4c123x-hal/src/sysctl.rs
+++ b/tm4c123x-hal/src/sysctl.rs
@@ -21,11 +21,13 @@
 //!
 //! See the LM4F120 datasheet, page 228 for a full list.
 
-use crate::bb;
-use crate::time::{Hertz, U32Ext};
-use cortex_m::asm::nop;
-
 pub use tm4c_hal::sysctl::*;
+
+use crate::{
+    bb,
+    time::{Hertz, U32Ext},
+};
+use cortex_m::asm::nop;
 
 /// Constrained SYSCTL peripheral.
 pub struct Sysctl {

--- a/tm4c123x-hal/src/timer.rs
+++ b/tm4c123x-hal/src/timer.rs
@@ -1,16 +1,17 @@
 //! Timers
 
-extern crate embedded_hal as hal;
-
-use tm4c_hal::time::Hertz;
-
-use crate::sysctl;
-use hal::timer::{CountDown, Periodic};
+use crate::{
+    hal::timer::{CountDown, Periodic},
+    sysctl::{self, Clocks},
+};
 use nb;
-use tm4c123x::{TIMER0, TIMER1, TIMER2, TIMER3, TIMER4, TIMER5};
-use tm4c123x::{WTIMER0, WTIMER1, WTIMER2, WTIMER3, WTIMER4, WTIMER5};
 
-use crate::sysctl::Clocks;
+#[rustfmt::skip]
+use tm4c123x::{
+    TIMER0, TIMER1, TIMER2, TIMER3, TIMER4, TIMER5,
+    WTIMER0, WTIMER1, WTIMER2, WTIMER3, WTIMER4, WTIMER5,
+};
+use tm4c_hal::time::Hertz;
 use void::Void;
 
 /// Hardware timers

--- a/tm4c129x-hal/src/gpio.rs
+++ b/tm4c129x-hal/src/gpio.rs
@@ -36,9 +36,11 @@
 
 pub use tm4c_hal::gpio::*;
 
-use crate::bb;
-use crate::hal::digital::{InputPin, OutputPin, StatefulOutputPin};
-use crate::sysctl;
+use crate::{
+    bb,
+    hal::digital::{InputPin, OutputPin, StatefulOutputPin},
+    sysctl,
+};
 use core::marker::PhantomData;
 use tm4c_hal::gpio_macro;
 

--- a/tm4c129x-hal/src/i2c.rs
+++ b/tm4c129x-hal/src/i2c.rs
@@ -1,10 +1,11 @@
 //! Inter-Integrated Circuit (I2C) bus
 
-use crate::gpio::*;
-use crate::gpio::{AlternateFunction, Floating, OpenDrain, OutputMode, AF3};
-use crate::hal::blocking::i2c::{Read, Write, WriteRead};
-use crate::sysctl::{self, Clocks};
-use crate::time::Hertz;
+use crate::{
+    gpio::*,
+    hal::blocking::i2c::{Read, Write, WriteRead},
+    sysctl::{self, Clocks},
+    time::Hertz,
+};
 use cortex_m::asm::delay;
 use tm4c129x::{I2C0, I2C1, I2C2, I2C3};
 

--- a/tm4c129x-hal/src/lib.rs
+++ b/tm4c129x-hal/src/lib.rs
@@ -25,9 +25,8 @@
 #![deny(warnings)]
 #![allow(deprecated)]
 
-pub use tm4c_hal::bb;
-pub use tm4c_hal::delay;
-pub use tm4c_hal::time;
+pub use tm4c129x::{self, CorePeripherals, Peripherals};
+pub use tm4c_hal::{bb, delay, time};
 
 pub mod gpio;
 pub mod i2c;
@@ -37,5 +36,3 @@ pub mod serial;
 pub mod sysctl;
 
 use embedded_hal as hal;
-pub use tm4c129x;
-pub use tm4c129x::{CorePeripherals, Peripherals};

--- a/tm4c129x-hal/src/prelude.rs
+++ b/tm4c129x-hal/src/prelude.rs
@@ -1,6 +1,9 @@
 //! Prelude
 
-pub use crate::gpio::GpioExt as _tm4c129x_hal_gpio_GpioExt;
-pub use crate::hal::prelude::*;
-pub use crate::sysctl::SysctlExt;
-pub use crate::time::U32Ext;
+#[rustfmt::skip]
+pub use crate::{
+    gpio::GpioExt as _,
+    hal::prelude::*,
+    sysctl::SysctlExt,
+    time::U32Ext,
+};

--- a/tm4c129x-hal/src/serial.rs
+++ b/tm4c129x-hal/src/serial.rs
@@ -1,23 +1,18 @@
 //! Serial
 
-use core::fmt;
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
-use crate::hal::prelude::*;
-use crate::hal::serial;
+use crate::{
+    gpio::*,
+    hal::{prelude::*, serial},
+    sysctl::{self, Clocks},
+    time::Bps,
+};
 use nb::{self, block};
-pub use tm4c129x::{UART0, UART1, UART2, UART3, UART4, UART5, UART6, UART7};
 use void::Void;
 
-use crate::gpio::*;
-use crate::gpio::{AlternateFunction, OutputMode, AF1};
-use crate::sysctl;
-use crate::sysctl::Clocks;
-use crate::time::Bps;
-
-pub use tm4c_hal::serial::*;
-
-pub use tm4c_hal::{uart_hal_macro, uart_pin_macro};
+pub use tm4c129x::{UART0, UART1, UART2, UART3, UART4, UART5, UART6, UART7};
+pub use tm4c_hal::{serial::*, uart_hal_macro, uart_pin_macro};
 
 /// Serial abstraction
 pub struct Serial<UART, TX, RX, RTS, CTS> {

--- a/tm4c129x-hal/src/spi.rs
+++ b/tm4c129x-hal/src/spi.rs
@@ -2,14 +2,17 @@
 
 pub use crate::hal::spi::{Mode, MODE_0, MODE_1, MODE_2, MODE_3};
 
-use crate::gpio::gpioa::{PA2, PA4, PA5};
-use crate::gpio::gpiob::{PB4, PB6, PB7};
-use crate::gpio::gpiod::{PD0, PD2, PD3};
-use crate::gpio::{AlternateFunction, OutputMode, AF1, AF2};
-use crate::hal::spi::{FullDuplex, Phase, Polarity};
-use crate::sysctl;
-use crate::sysctl::Clocks;
-use crate::time::Hertz;
+use crate::{
+    gpio::{
+        gpioa::{PA2, PA4, PA5},
+        gpiob::{PB4, PB6, PB7},
+        gpiod::{PD0, PD2, PD3},
+        AlternateFunction, OutputMode, AF1, AF2,
+    },
+    hal::spi::{FullDuplex, Phase, Polarity},
+    sysctl::{self, Clocks},
+    time::Hertz,
+};
 
 use nb;
 use tm4c129x::{SSI0, SSI1, SSI2, SSI3};

--- a/tm4c129x-hal/src/sysctl.rs
+++ b/tm4c129x-hal/src/sysctl.rs
@@ -21,11 +21,13 @@
 //!
 //! See the LM4F120 datasheet, page 228 for a full list.
 
-use crate::bb;
-use crate::time::{Hertz, U32Ext};
-use cortex_m::asm::nop;
-
 pub use tm4c_hal::sysctl::*;
+
+use crate::{
+    bb,
+    time::{Hertz, U32Ext},
+};
+use cortex_m::asm::nop;
 
 /// Constrained SYSCTL peripheral.
 pub struct Sysctl {


### PR DESCRIPTION
The imports in most files appear to have been incompletely converted from edition 2015 to edition 2018, with some duplicates and repeated prefixes. Additionally, some crate attributes were set separately when they could have been set jointly.

This change cleans up imports and consolidates crate attributes. Some import sections have been annotated `#[rustfmt::skip]` and manually formatted for readability.